### PR TITLE
Default Channel Setting

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,8 +2,11 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["IPV6", "COMMON_PAL"],
-            "mbed-mesh-api.6lowpan-nd-channel": 15,
-            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<15)"
+            "mbed-mesh-api.6lowpan-nd-channel-page": 0,
+            "mbed-mesh-api.6lowpan-nd-channel": 12,
+            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<12)",
+            "mbed-mesh-api.thread-config-panid": "0xDEFA",
+            "mbed-mesh-api.thread-config-channel": 12
         }
     }
 }


### PR DESCRIPTION
- Setting the default channel to be 12 in order to match the
  GW Binary available in one of the applications.
