### PR TITLE
Update mbed-os to mbed-os-5.2.3

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196
+https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51
+https://github.com/ARMmbed/mbed-os/#342e565214a5043232b5ce2cdad46fbf75de6196


### PR DESCRIPTION
This PR is to update mbed-os library to mbed-os-5.2.3. Before accepting please run suitable tests to ensure that this update is compatible with this example. Decline the PR if you do not wish to accept.