### PR TITLE
Build against different mbed-os revisions & hw smoke

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,39 @@
+properties ([[
+  $class: 'ParametersDefinitionProperty',
+  parameterDefinitions: [[
+    $class: 'StringParameterDefinition',
+    name: 'mbed_os_revision',
+    defaultValue: 'master',
+    description: 'Revision of mbed-os to build'
+    ]]
+  ]])
+
+// There seems to be a bug in Jenkins, the first build of every branch fails due to missing parameters.
+try {
+  echo "Verifying build with mbed-os version ${mbed_os_revision}"
+  env.MBED_OS_REVISION = "${mbed_os_revision}"
+} catch (err) {
+  def mbed_os_revision = "master"
+  echo "Verifying build with mbed-os version ${mbed_os_revision}"
+  env.MBED_OS_REVISION = "${mbed_os_revision}"
+}
+
+// Map RaaS instances to corresponding test suites
+def raas = [
+  "8001": "lowpan_mesh_minimal_smoke_k64f_atmel.json"
+  //"8034": "lowpan_mesh_minimal_smoke_k64f_mcr20.json",
+  //"8030": "lowpan_mesh_minimal_smoke_429zi_atmel.json",
+  //"8033": "lowpan_mesh_minimal_smoke_429zi_mcr20.json",
+  //"8031": "lowpan_mesh_minimal_smoke_ublox_atmel.json"
+    ]
+
 // List of targets with supported RF shields to compile
 def targets = [
   "K64F": ["ATMEL", "MCR20"],
   //"NUCLEO_F401RE": ["ATMEL", "MCR20"],
   "NUCLEO_F429ZI": ["ATMEL", "MCR20"],
   //"NCS36510": ["NCS36510"],
-  "UBLOX_EVK_ODIN_W2": ["ATMEL", "MCR20"]
+  "UBLOX_EVK_ODIN_W2": ["ATMEL"]
   ]
   
 // Map toolchains to compilers
@@ -49,8 +78,16 @@ for (int i = 0; i < targets.size(); i++) {
   }
 }
 
+def parallelRunSmoke = [:]
+
+for(int i = 0; i < raas.size(); i++){
+  def raasPort = raas.keySet().asList().get(i)
+  parallelRunSmoke[raasPort] = run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort)
+}
+
 timestamps {
   parallel stepsForParallel
+  parallel parallelRunSmoke
 }
 
 def buildStep(target, compilerLabel, toolchain, radioShield, meshInterface) {
@@ -83,16 +120,61 @@ def buildStep(target, compilerLabel, toolchain, radioShield, meshInterface) {
           // Use systest border router for testing
             execute("sed -i 's/\"mbed-mesh-api.6lowpan-nd-channel\": 12/\"mbed-mesh-api.6lowpan-nd-channel\": 18/' mbed_app.json")
           }
-  
+
+          // Set mbed-os to revision received as parameter
+          writeFile file: 'mbed-os.lib', text: "https://github.com/ARMmbed/mbed-os/"
           execute ("mbed deploy --protocol ssh")
-          // Checkout latest mbed-os master
-          dir("mbed-os") {
-            execute ("git fetch origin master")
-            execute ("git checkout FETCH_HEAD")
+
+          if("${env.MBED_OS_REVISION}" != "master") {
+            dir ("mbed-os") {
+              execute ("git fetch origin ${env.MBED_OS_REVISION}")
+              execute ("git checkout FETCH_HEAD")
+            }
           }
           execute ("mbed compile --build out/${target}_${toolchain}_${radioShield}_${meshInterface}/ -m ${target} -t ${toolchain} -c")
         }
+        stash name: "${target}_${toolchain}_${radioShield}_${meshInterface}", includes: '**/mbed-os-example-mesh-minimal.bin'
         archive '**/mbed-os-example-mesh-minimal.bin'
+      }
+    }
+  }
+}
+
+def run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort){
+  return {
+    stage ("smoke_tests_${raasPort}") {
+      node ("linux_test") {
+        deleteDir()
+        }
+        dir("mbed-clitest") {
+          git "git@github.com:ARMmbed/mbed-clitest.git"
+          execute("git checkout ${env.LATEST_CLITEST_REL}")
+          execute("git submodule update --init --recursive testcases")
+
+          for (int i = 0; i < targets.size(); i++) {
+            for(int j = 0; j < toolchains.size(); j++) {
+              for(int k = 0; k < radioshields.size(); k++) {
+                for(int l = 0; l < meshinterfaces.size(); l++) {
+                  def target = targets.keySet().asList().get(i)
+                  def allowed_shields = targets.get(target)
+                  def toolchain = toolchains.keySet().asList().get(j)
+                  //def compilerLabel = toolchains.get(toolchain)
+                  def radioshield = radioshields.get(k)
+                  def meshInterface = meshinterfaces.get(l)
+                  if(allowed_shields.contains(radioshield)) {
+                    unstash "${target}_${toolchain}_${radioshield}_${meshInterface}"
+                  }
+                }
+              }
+            }
+          }
+
+          env.RAAS_USERNAME = "user"
+          env.RAAS_PASSWORD = "user"
+          def suite_to_run = raas.get(raasPort)
+          execute("python clitest.py --suitedir testcases/suites/ --suite ${suite_to_run} --type hardware --reset --raas 193.208.80.31:${raasPort} --failure_return_value -vvv -w --log log_${raasPort}")
+          archive "log_${raasPort}/**/*"
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,14 +121,11 @@ def buildStep(target, compilerLabel, toolchain, radioShield, meshInterface) {
           }
 
           // Set mbed-os to revision received as parameter
-          writeFile file: 'mbed-os.lib', text: "https://github.com/ARMmbed/mbed-os/"
           execute ("mbed deploy --protocol ssh")
-          if("${env.MBED_OS_REVISION}" != "master") {
-            dir ("mbed-os") {
-              execute ("git fetch origin ${env.MBED_OS_REVISION}")
-              execute ("git checkout FETCH_HEAD")
-            }
+          dir ("mbed-os") {
+            execute ("git checkout ${env.MBED_OS_REVISION}")
           }
+
           execute ("mbed compile --build out/${target}_${toolchain}_${radioShield}_${meshInterface}/ -m ${target} -t ${toolchain} -c")
         }
         stash name: "${target}_${toolchain}_${radioShield}_${meshInterface}", includes: '**/mbed-os-example-mesh-minimal.bin'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,12 @@ def raas = [
   "8034": "lowpan_mesh_minimal_smoke_k64f_mcr20.json",
   "8030": "lowpan_mesh_minimal_smoke_429zi_atmel.json",
   "8033": "lowpan_mesh_minimal_smoke_429zi_mcr20.json",
-  "8031": "lowpan_mesh_minimal_smoke_ublox_atmel.json"
+  "8031": "lowpan_mesh_minimal_smoke_ublox_atmel.json",
+  "8007": "thread_mesh_minimal_smoke_k64f_atmel.json",
+  "8034": "thread_mesh_minimal_smoke_k64f_mcr20.json",
+  "8030": "thread_mesh_minimal_smoke_429zi_atmel.json",
+  "8033": "thread_mesh_minimal_smoke_429zi_mcr20.json",
+  "8031": "thread_mesh_minimal_smoke_ublox_atmel.json"
   ]
 
 // List of targets with supported RF shields to compile

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,6 +150,13 @@ def run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort)
           execute("git checkout ${env.LATEST_CLITEST_REL}")
           execute("git submodule update --init --recursive testcases")
 
+          dir("testcases") {
+            execute("git checkout master")
+            dir("6lowpan") {
+              execute("git checkout master")
+            }
+          }
+
           for (int i = 0; i < targets.size(); i++) {
             for(int j = 0; j < toolchains.size(); j++) {
               for(int k = 0; k < radioshields.size(); k++) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,6 @@ def run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort)
     stage ("smoke_tests_${raasPort}") {
       node ("linux_test") {
         deleteDir()
-        }
         dir("mbed-clitest") {
           git "git@github.com:ARMmbed/mbed-clitest.git"
           execute("git checkout ${env.LATEST_CLITEST_REL}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ if ( smoke_test == "true" ) {
   for(int i = 0; i < raas.size(); i++) {
     def suite_to_run = raas.keySet().asList().get(i)
     def raasPort = raas.get(suite_to_run)
-    parallelRunSmoke[raasPort] = run_smoke(targets, toolchains, radioshields, meshinterfaces, raasPort, suite_to_run)
+    parallelRunSmoke[suite_to_run] = run_smoke(targets, toolchains, radioshields, meshinterfaces, raasPort, suite_to_run)
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ properties ([[
     ]]
   ]])
 
-// There seems to be a bug in Jenkins, the first build of every branch fails due to missing parameters.
 try {
   echo "Verifying build with mbed-os version ${mbed_os_revision}"
   env.MBED_OS_REVISION = "${mbed_os_revision}"
@@ -25,7 +24,7 @@ def raas = [
   //"8030": "lowpan_mesh_minimal_smoke_429zi_atmel.json",
   //"8033": "lowpan_mesh_minimal_smoke_429zi_mcr20.json",
   //"8031": "lowpan_mesh_minimal_smoke_ublox_atmel.json"
-    ]
+  ]
 
 // List of targets with supported RF shields to compile
 def targets = [
@@ -124,7 +123,6 @@ def buildStep(target, compilerLabel, toolchain, radioShield, meshInterface) {
           // Set mbed-os to revision received as parameter
           writeFile file: 'mbed-os.lib', text: "https://github.com/ARMmbed/mbed-os/"
           execute ("mbed deploy --protocol ssh")
-
           if("${env.MBED_OS_REVISION}" != "master") {
             dir ("mbed-os") {
               execute ("git fetch origin ${env.MBED_OS_REVISION}")
@@ -164,7 +162,6 @@ def run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort)
                   def target = targets.keySet().asList().get(i)
                   def allowed_shields = targets.get(target)
                   def toolchain = toolchains.keySet().asList().get(j)
-                  //def compilerLabel = toolchains.get(toolchain)
                   def radioshield = radioshields.get(k)
                   def meshInterface = meshinterfaces.get(l)
                   if(allowed_shields.contains(radioshield)) {
@@ -174,7 +171,6 @@ def run_smoke(targets, toolchains, radioshields, meshinterfaces, raas, raasPort)
               }
             }
           }
-
           env.RAAS_USERNAME = "user"
           env.RAAS_PASSWORD = "user"
           def suite_to_run = raas.get(raasPort)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties ([[$class: 'ParametersDefinitionProperty', parameterDefinitions: [
   [$class: 'StringParameterDefinition', name: 'mbed_os_revision', defaultValue: 'master', description: 'Revision of mbed-os to build'],
-  [$class: 'BooleanParameterDefinition', name: 'smoke_test', defaultValue: false, description: 'Enable to run HW smoke test after building']
+  [$class: 'BooleanParameterDefinition', name: 'smoke_test', defaultValue: true, description: 'Enable to run HW smoke test after building']
   ]]])
 
 echo "Run smoke tests: ${smoke_test}"
@@ -87,7 +87,8 @@ if ( smoke_test == "true" ) {
     for(int j = 0; j < meshinterfaces.size(); j++) {
       def raasPort = raas.keySet().asList().get(i)
       def meshMode = meshinterfaces.get(j)
-      parallelRunSmoke[raasPort] = run_smoke(targets, toolchains, radioshields, meshMode, raas, raasPort)
+      def smokeStep = "${raasPort} ${meshMode}"
+      parallelRunSmoke[smokeStep] = run_smoke(targets, toolchains, radioshields, meshMode, raas, raasPort)
     }
   }
 }


### PR DESCRIPTION
Build against different mbed-os revisions & hw smoke

* Added ability to build against different mbed-os branches (default being master)
- Triggered from Jenkins "Build with parameters"
* Removed non compatible Ublox & mcr20 build combination
* Added a simple hw smoke test as the final stage with K64F & atmel combination
- Smoke test is not 100% reliable yet (ONME-2882).

@SeppoTakalo @artokin 