### PR TITLE
json config created for 6LoWPAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,15 @@ To learn why entropy is required, read the [TLS Porting guide](https://docs.mbed
 
 ### Compile the application
 
+#### For 6LoWPAN
 ```
-mbed compile -m K64F -t GCC_ARM
+mbed compile -m K64F -t GCC_ARM --app-config configs/mesh_6lowpan.json
+```
+
+#### For Thread
+
+```
+mbed compile -m K64F -t GCC_ARM --app-config configs/mesh_thread.json
 ```
 
 A binary is generated at the end of the build process.
@@ -101,7 +108,7 @@ Drag and drop the binary to the target to program the application.
 
 This example supports the following two border routers:
 
-- [k64f-border-router](https://github.com/ARMmbed/k64f-border-router), 6LoWPAN only
+- [Nanostack-border-router](https://github.com/ARMmbed/nanostack-border-router-private), 6LoWPAN only
 - [mbed gateway](https://firefly-iot.com/product/firefly-6lowpan-gateway-2-4ghz/)
  
 Read the instructions on updating the firmware of your mbed gateway working as 6LoWPAN [here](https://github.com/ARMmbed/mbed-os-example-client#mbed-gateway).

--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "trace": {
+        	"help": "options are true, false",
+        	"value": true
+        },
+        "radio-type":{
+            "help": "options are ATMEL, MCR20, NCS36510",
+            "value": "ATMEL"
+        },
+        "mesh-type":{
+            "help": "options are MESH_LOWPAN, MESH_THREAD",
+            "value": "MESH_LOWPAN"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["NANOSTACK", "LOWPAN_ROUTER", "COMMON_PAL"],
+            "mbed-mesh-api.6lowpan-nd-panid-filter": "0xffff",            
+            "mbed-mesh-api.6lowpan-nd-channel-page": 0,
+            "mbed-mesh-api.6lowpan-nd-channel": 12,
+            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<12)",            
+            "mbed-mesh-api.heap-size": 14000,
+            "mbed-trace.enable": false,
+            "platform.stdio-convert-newlines": true,
+            "platform.stdio-baud-rate": 115200
+        }
+    }
+}


### PR DESCRIPTION
own config for 6lowpan.
Userguide updated to show compile commands with configs.
Userguide pointing to nanostack-border-router

@SeppoTakalo @artokin 