### PR TITLE
Add support for KW24D

### DIFF
--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "radio-type":{
-            "help": "options are ATMEL, MCR20, NCS36510",
+            "help": "options are ATMEL, MCR20, NCS36510, KW24D",
             "value": "ATMEL"
         },
         "mesh-type":{

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "radio-type":{
-            "help": "options are ATMEL, MCR20, NCS36510",
+            "help": "options are ATMEL, MCR20, NCS36510, KW24D",
             "value": "ATMEL"
         },
         "mesh-type":{

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,7 @@ void trace_printer(const char* str) {
 #define ATMEL   1
 #define MCR20   2
 #define NCS36510 3
+#define KW24D   4
 
 #define MESH_LOWPAN     3
 #define MESH_THREAD     4
@@ -35,7 +36,7 @@ void trace_printer(const char* str) {
 #include "NanostackRfPhyAtmel.h"
 NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
                            ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
-#elif MBED_CONF_APP_RADIO_TYPE == MCR20
+#elif MBED_CONF_APP_RADIO_TYPE == MCR20 || MBED_CONF_APP_RADIO_TYPE == KW24D 
 #include "NanostackRfPhyMcr20a.h"
 NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
 

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "radio-type":{
-            "help": "options are ATMEL, MCR20, NCS36510",
+            "help": "options are ATMEL, MCR20, NCS36510, KW24D",
             "value": "ATMEL"
         },
         "mesh-type":{


### PR DESCRIPTION
Although KW24D uses the same MCR20A driver, it is nice to explicitly list KW24D as supported and make it easy for users to choose it in the application if they like.