### PR TITLE
Thread device type changed to MED

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,6 +120,9 @@ def buildStep(target, compilerLabel, toolchain, radioShield, meshInterface) {
             // Use systest Thread Border Router for testing (CH=18, PANID=BAAB)
             execute("sed -i '/mbed-mesh-api.thread-device-type\":/a \"mbed-mesh-api.thread-config-channel\": 18,' ${config_file}")
             execute("sed -i '/mbed-mesh-api.thread-device-type\":/a \"mbed-mesh-api.thread-config-panid\": \"0xBAAB\",' ${config_file}")
+            execute("sed -i 's/\"NANOSTACK\", \"THREAD_ROUTER\", \"COMMON_PAL\"/\"NANOSTACK\", \"THREAD_END_DEVICE\", \"COMMON_PAL\"/'  ${config_file}")
+            execute("sed -i 's/\"mbed-mesh-api.thread-device-type\": \"MESH_DEVICE_TYPE_THREAD_ROUTER\"/\"mbed-mesh-api.thread-device-type\": \"MESH_DEVICE_TYPE_THREAD_MINIMAL_END_DEVICE\"/' ${config_file}")
+
           }
 
           if ("${meshInterface}" == "6lp") {


### PR DESCRIPTION
Application Thread device type changed to MED from of ROUTER.
Router device generates address automatically and therefore border
router connection was not needed. With MED device type border router
is needed to get device bootstrapped.


Note! Thsi change requires mbed-os-5.5