### PR TITLE
Add NCS36510 definitions for led control example

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -38,6 +38,10 @@
         "NUCLEO_F401RE": {
             "LED": "LED_RED",
             "BUTTON": "USER_BUTTON"
+        },
+	 "NCS36510": {
+            "LED": "LED1",
+            "BUTTON": "SW2"
         }
     }
 }


### PR DESCRIPTION
Add to target overrides for NCS36510 LED and BUTTON macros used in the example.