### PR TITLE
[ONME-3113] Fix ARM compiler warnings

### DIFF
--- a/atmel-rf-driver.lib
+++ b/atmel-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/atmel-rf-driver/#0ae76ce17ae53766875dbdebb02d6a0f50928847
+https://github.com/ARMmbed/atmel-rf-driver/#3cc6010188c0136d9ccfc27658b0d5d45e419e94

--- a/main.cpp
+++ b/main.cpp
@@ -53,11 +53,6 @@ LoWPANNDInterface mesh;
 ThreadInterface mesh;
 #endif //MBED_CONF_APP_MESH_TYPE
 
-extern "C" {
-    static void serial_out_mutex_wait();
-    static void serial_out_mutex_release();
-}
-
 static Mutex SerialOutMutex;
 
 void serial_out_mutex_wait()
@@ -87,8 +82,8 @@ int main()
 
     printf("\n\nConnecting...\n");
     mesh.initialize(&rf_phy);
-    int error=-1;
-    if ((error=mesh.connect())) {
+    int error = mesh.connect();
+    if (error) {
         printf("Connection failed! %d\n", error);
         return error;
     }

--- a/mcr20a-rf-driver.lib
+++ b/mcr20a-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mcr20a-rf-driver/#d5905fefa54c0de9b757d6f1c87c8ae9ee337543
+https://github.com/ARMmbed/mcr20a-rf-driver/#9aac10474702659c20bde3d2f444f14af440a2c9


### PR DESCRIPTION
[Warning] #1293-D: assignment in condition

[Warning] #177-D: function "serial_out_mutex_wait"  was declared
but never referenced

[Warning] #177-D: function "serial_out_mutex_release"  was declared
but never referenced