### PR TITLE
Fix led pin collision with NUCLEO_F401RE and NUCLEO_F411RE

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -34,12 +34,16 @@
         "K66F": {
             "LED": "LED_RED",
             "BUTTON": "SW2"
-		    },
+        },
         "NUCLEO_F401RE": {
-            "LED": "LED_RED",
+            "LED": "NC",
             "BUTTON": "USER_BUTTON"
         },
-	      "NCS36510": {
+        "NUCLEO_F411RE": {
+            "LED": "NC",
+            "BUTTON": "USER_BUTTON"
+        },
+        "NCS36510": {
             "LED": "LED1",
             "BUTTON": "SW2"
         },


### PR DESCRIPTION
The LED is in the same pin as SPI1_SCK and therefore cannot be
used with radio shield.

Fixes #126