### PR TITLE
Fix an incorrect multicast address.

### DIFF
--- a/mesh_led_control_example.cpp
+++ b/mesh_led_control_example.cpp
@@ -28,7 +28,7 @@ static void send_message();
 static void blink();
 
 // mesh local multicast to all nodes
-#define multicast_addr_str "ff03::1"
+#define multicast_addr_str "ff02::1"
 #define TRACE_GROUP "example"
 #define UDP_PORT 1234
 #define MESSAGE_WAIT_TIMEOUT (30.0)


### PR DESCRIPTION
ff03::1 is not good for multicast address.
please refer [the issue details at here](https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/130).