### PR TITLE
Removed led from nucleo F401RE configuration

### DIFF
--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -34,7 +34,7 @@
             "BUTTON": "SW2"
 		},
         "NUCLEO_F401RE": {
-            "LED": "LED_RED",
+            "LED": "NC",
             "BUTTON": "USER_BUTTON"
         }
     }

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -31,7 +31,7 @@
             "BUTTON": "SW2"
 		},
         "NUCLEO_F401RE": {
-            "LED": "LED_RED",
+            "LED": "NC",
             "BUTTON": "USER_BUTTON"
         },
         "KW24D": {


### PR DESCRIPTION
In nucleo board, LED_RED pin is overlapping with radio shield SPI. Removing led
from configuration.