### PR TITLE
ONME-3199: Leave out channel mask from default settings.

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -19,7 +19,6 @@
             "mbed-mesh-api.6lowpan-nd-panid-filter": "0xffff",
             "mbed-mesh-api.6lowpan-nd-channel-page": 0,
             "mbed-mesh-api.6lowpan-nd-channel": 12,
-            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<12)",
             "mbed-mesh-api.thread-config-panid": "0x0700",
             "mbed-mesh-api.thread-master-key": "{0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}",
             "mbed-mesh-api.thread-config-channel": 22,


### PR DESCRIPTION
Usually you only need to specify channel or leave it zero.

For zero-channel to work, this change has to be merged in https://github.com/ARMmbed/mbed-os/pull/5736
