### PR TITLE
Ensure Nanostack is initialised before using it

### DIFF
--- a/mesh_nvm.cpp
+++ b/mesh_nvm.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "mbed.h"
+#include "Nanostack.h"
 
 /* Application configuration values from json */
 #define MESH_LOWPAN     1
@@ -68,7 +69,9 @@ void mesh_nvm_initialize()
     }
 
     if (!mount_status) {
+        Nanostack::get_instance(); // ensure Nanostack is initialised
         ns_file_system_set_root_path("/fs/");
+        // Should be like: Nanostack::get_instance().file_system_set_root_path("/fs/");
     }
 }
 


### PR DESCRIPTION
Nanostack initialisation will occur after the first call to:
 Nanostack::get_instance

Set file system root path after Nanostack initialisation.