### PR TITLE
Add a configuration option for button mode

### DIFF
--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -10,7 +10,8 @@
         },
         "enable-led-control-example": true,
         "LED": "NC",
-        "BUTTON": "NC"
+        "BUTTON": "NC",
+        "BUTTON_MODE": "PullUp"
     },
     "target_overrides": {
         "*": {
@@ -36,6 +37,11 @@
         "NUCLEO_F401RE": {
             "LED": "NC",
             "BUTTON": "USER_BUTTON"
+        },
+        "NUCLEO_F429ZI":  {
+            "LED": "LED_RED",
+            "BUTTON": "USER_BUTTON",
+            "BUTTON_MODE": "PullDown"
         }
     }
 }

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -14,7 +14,8 @@
         },
         "enable-led-control-example": true,
         "LED": "NC",
-        "BUTTON": "NC"
+        "BUTTON": "NC",
+        "BUTTON_MODE": "PullUp"
     },
     "target_overrides": {
         "*": {
@@ -41,6 +42,11 @@
         "KW24D": {
             "LED": "LED1",
             "BUTTON": "SW1"
+        },
+        "NUCLEO_F429ZI":  {
+            "LED": "LED_RED",
+            "BUTTON": "USER_BUTTON",
+            "BUTTON_MODE": "PullDown"
         }
     }
     

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -10,7 +10,8 @@
         },
         "enable-led-control-example": true,
         "LED": "NC",
-        "BUTTON": "NC"
+        "BUTTON": "NC",
+        "BUTTON_MODE": "PullUp"
     },
     "target_overrides": {
         "*": {
@@ -51,6 +52,11 @@
         "KW24D": {
             "LED": "LED1",
             "BUTTON": "SW1"
+        },
+        "NUCLEO_F429ZI":  {
+            "LED": "LED_RED",
+            "BUTTON": "USER_BUTTON",
+            "BUTTON_MODE": "PullDown"
         }
     }
 }

--- a/mesh_led_control_example.cpp
+++ b/mesh_led_control_example.cpp
@@ -198,7 +198,7 @@ static void init_socket()
 
     if (MBED_CONF_APP_BUTTON != NC) {
         my_button.fall(&my_button_isr);
-        my_button.mode(PullUp);
+        my_button.mode(MBED_CONF_APP_BUTTON_MODE);
     }
     //let's register the call-back function.
     //If something happens in socket (packets in or out), the call-back is called.


### PR DESCRIPTION
NUCLEO_F429ZI features an user button which needs the mode to be PullDown instead of PullUp. The configuration defaults to PullUp and can be overridden.

Related issue: https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/193