### PR TITLE
Interface is created at mesh->connect(), so moving thread_eui64_trace() call after it.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -80,7 +80,6 @@ int main()
         return -1;
     }
 
-    thread_eui64_trace();
     mesh_nvm_initialize();
     printf("Connecting...\n");
     int error = mesh->connect();
@@ -88,6 +87,7 @@ int main()
         printf("Connection failed! %d\n", error);
         return error;
     }
+    thread_eui64_trace();
 
     while (NULL == mesh->get_ip_address())
         Thread::wait(500);


### PR DESCRIPTION
This will fix the issue, that valid mac addres is red and printed out correctly