### PR TITLE
Refresh tables contents and fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,29 +68,23 @@ An example of the `mbed_app.json` file:
         },
 ```
 
-The following tables show the values to use in the `mbed_app.json` file for your devices in different networks.
-
-- For a 6LoWPAN-ND based network, use `nsapi.default-mesh-type: LOWPAN`.
-- For a Thread-based network, use `nsapi.default-mesh-type: THREAD`.
-- For a Wi-SUN-based network, use `nsapi.default-mesh-type: WISUN`.
-
 #### 6LoWPAN-ND
 
 **nsapi.default-mesh-type: LOWPAN**
 
-|Device role|`nanostack.configuration` value|`mbed-mesh-api.6lowpan-nd-device-type` value|
-|-----------|-------------------------|------------------------------------|
-|Mesh router (default) | lowpan_router | NET_6LOWPAN_ROUTER |
-|Nonrouting device | lowpan_host | NET_6LOWPAN_HOST |
+| Device role           | `"nsapi.default-mesh-type"` | `"nanostack.configuration"` | `"mbed-mesh-api.6lowpan-nd-device-type"` |
+|:----------------------|:----------------------------|:----------------------------|:-----------------------------------------|
+| Mesh router (default) | `"LOWPAN"`                  | `"lowpan_router"`           | `"NET_6LOWPAN_ROUTER"`                   |
+| Nonrouting device     | `"LOWPAN"`                  | `"lowpan_host"`             | `"NET_6LOWPAN_HOST"`                     |
 
 #### Thread
 
 **nsapi.default-mesh-type: THREAD**
 
-|Device role|`nanostack.configuration` value|`mbed-mesh-api.thread-device-type` value|
-|-----------|-------------------------|------------------------------------|
-|Mesh router (default) | thread_router | MESH_DEVICE_TYPE_THREAD_ROUTER |
-|Nonrouting device | thread_end_device | MESH_DEVICE_TYPE_THREAD_SLEEPY_END_DEVICE |
+| Device role           | `"nsapi.default-mesh-type"` | `"nanostack.configuration"` | `"mbed-mesh-api.thread-device-type"`          |
+|:----------------------|:----------------------------|:----------------------------|:----------------------------------------------|
+| Mesh router (default) | `"THREAD"`                  | `"thread_router"`           | `"MESH_DEVICE_TYPE_THREAD_ROUTER"`            |
+| Nonrouting device     | `"THREAD"`                  | `"thread_end_device"`       | `"MESH_DEVICE_TYPE_THREAD_SLEEPY_END_DEVICE"` |
 
 ##### Thread commissioning
 
@@ -110,9 +104,9 @@ The Thread stack learns the network settings from the commissioning process and 
 
 **nsapi.default-mesh-type: WISUN**
 
-|Device role|`nanostack.configuration` value|
-|-----------|-------------------------|
-|Mesh router (default) | ws_router |
+| Device role           | `"nsapi.default-mesh-type"` | `"nanostack.configuration"` |
+|:----------------------|:----------------------------|:----------------------------|
+| Mesh router (default) | `"WISUN"`                   | `"ws_router"`               |
 
 
 ### Requirements for hardware
@@ -120,7 +114,7 @@ The Thread stack learns the network settings from the commissioning process and 
 The networking stack used in this example requires TLS functionality to be enabled on Mbed TLS.
 On devices where hardware entropy is not present, TLS is disabled by default. This results in compile time failures or linking failures.
 
-To learn why entropy is required, read the [TLS Porting guide](https://os.mbed.com/docs/latest/reference/mbed-tls-entropy.html).
+To learn why entropy is required, read the [Entropy Sources Porting guide](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/porting/target/entropy.md).
 
 See [Notes on different hardware](https://github.com/ARMmbed/mbed-os-example-mesh-minimal/blob/master/Hardware.md) for known combinations of development boards and RF shields that have been tested.
 


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/260
Fixes https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/262
The tables were rewritten as @korjaa did in https://github.com/ARMmbed/mbed-os-example-mesh-minimal/pull/261.