### PR TITLE
Extend bootstrap waiting loops 105->115

### DIFF
--- a/TEST_APPS/testcases/mesh_minimal_startup.py
+++ b/TEST_APPS/testcases/mesh_minimal_startup.py
@@ -63,7 +63,7 @@ class Testcase(Bench):
         # 2. Verify 6LoWPAN bootstrap (fails to timeout or bootstrap failure trace)
         bootstrap_complete = "Connected. IP ="
         bootstrap_fail = "Connection failed!"
-        loops = 105 # Connection can take up a long time (>1020 seconds in case of Wi-SUN).
+        loops = 115 # Connection can take up a long time (>1020 seconds in case of Wi-SUN).
         for i in range (1, loops + 1):
             self.logger.info("Waiting for connection " + str(i) + "/" + str(loops))
             self.delay(10)


### PR DESCRIPTION
1050 seconds appears to be a little too close in Wi-SUN case. Test fails a bit too often. Propose increasing waiting period to 1150.