### PR TITLE
Remove deprecated string-based API

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -89,10 +89,11 @@ int main()
         return error;
     }
 
-    while (NULL == mesh->get_ip_address())
+    SocketAddress sockAddr;
+    while (NSAPI_ERROR_OK != mesh->get_ip_address(&sockAddr))
         ThisThread::sleep_for(500);
 
-    printf("Connected. IP = %s\n", mesh->get_ip_address());
+    printf("Connected. IP = %s\n", sockAddr.get_ip_address());
 
 #if MBED_CONF_APP_ENABLE_LED_CONTROL_EXAMPLE
     // Network found, start socket example


### PR DESCRIPTION
String-based APIs were marked deprecated and replaced by `SocketAddress`-based APIs in https://github.com/ARMmbed/mbed-os/pull/11914.
This PR switches the example to the new API and removes the deprecated one.
To get this compile I updated `mbed-os.lib` to 5.15.