### PR TITLE
Include deprecated API removal in the mbed-os-5.15 branch

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -89,10 +89,11 @@ int main()
         return error;
     }
 
-    while (NULL == mesh->get_ip_address())
+    SocketAddress sockAddr;
+    while (NSAPI_ERROR_OK != mesh->get_ip_address(&sockAddr))
         ThisThread::sleep_for(500);
 
-    printf("Connected. IP = %s\n", mesh->get_ip_address());
+    printf("Connected. IP = %s\n", sockAddr.get_ip_address());
 
 #if MBED_CONF_APP_ENABLE_LED_CONTROL_EXAMPLE
     // Network found, start socket example


### PR DESCRIPTION
This is to include the string-based API deprecation in the 5.15 release. This will allow us to pass CI checks in https://github.com/ARMmbed/mbed-os/pull/11942, which removes the deprecated API and is required for the upcoming mbed-os-6 release.