### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def targets = [
   "NUCLEO_F401RE": ["ATMEL", "MCR20A"],
   "NUCLEO_F429ZI": ["ATMEL", "MCR20A", "S2LP"],
   //"NCS36510": ["internal"],
-  "UBLOX_EVK_ODIN_W2": ["ATMEL"],
+  //"UBLOX_EVK_ODIN_W2": ["ATMEL"],
   "KW24D": ["internal"],
   "KW41Z": ["internal"]
   ]


### PR DESCRIPTION
Remove UBLOX_EVK_ODIN_W2 from Jenkinsfile build as MCU is not a
supported MCU in Mbed OS.