### PR TITLE
Add S2LP driver pin config to application

### DIFF
--- a/configs/mesh_wisun_S2LP.json
+++ b/configs/mesh_wisun_S2LP.json
@@ -35,6 +35,19 @@
             "LED": "LED_RED",
             "BUTTON": "USER_BUTTON",
             "BUTTON_MODE": "PullDown"
+        },
+        "MTB_STM_S2LP": {
+            "s2lp.SPI_SDI"  : "PA_7",
+            "s2lp.SPI_SDO"  : "PA_6",
+            "s2lp.SPI_SCLK" : "PA_5",
+            "s2lp.SPI_CS"   : "PC_0",
+            "s2lp.SPI_SDN"  : "PF_13",
+            "s2lp.SPI_GPIO0": "PA_3",
+            "s2lp.SPI_GPIO1": "PC_3",
+            "s2lp.SPI_GPIO2": "PF_3",
+            "s2lp.SPI_GPIO3": "PF_10",
+            "s2lp.I2C_SDA"  : "PB_7",
+            "s2lp.I2C_SCL"  : "PB_6"
         }
     }
 }


### PR DESCRIPTION
New S2LP driver does not provide PIN configuration for MTB_STM_S2LP
board. Define pins in the application configuration file.