### PR TITLE
Update Arduino pin names

### DIFF
--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -24,12 +24,12 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "KW24D": {
@@ -42,16 +42,16 @@
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",

--- a/configs/mesh_6lowpan.json
+++ b/configs/mesh_6lowpan.json
@@ -26,7 +26,7 @@
         "K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_6lowpan_ATMEL.json
+++ b/configs/mesh_6lowpan_ATMEL.json
@@ -24,34 +24,34 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
-            "BUTTON": "SW2",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
-            "BUTTON": "SW2"
+            "LED": "LED1",
+            "BUTTON": "BUTTON1"
         },
         "KW24D": {
             "LED": "LED1",
-            "BUTTON": "SW1"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",
-            "BUTTON": "SW2"
+            "BUTTON": "BUTTON1"
         }
     }
 }

--- a/configs/mesh_6lowpan_ATMEL.json
+++ b/configs/mesh_6lowpan_ATMEL.json
@@ -26,7 +26,7 @@
         "K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_6lowpan_MCR20A.json
+++ b/configs/mesh_6lowpan_MCR20A.json
@@ -24,12 +24,12 @@
             "target.network-default-interface-type": "MESH"
         },
       	"K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "KW24D": {
@@ -38,16 +38,16 @@
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",

--- a/configs/mesh_6lowpan_MCR20A.json
+++ b/configs/mesh_6lowpan_MCR20A.json
@@ -26,7 +26,7 @@
       	"K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -28,7 +28,7 @@
         "K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_thread.json
+++ b/configs/mesh_thread.json
@@ -26,12 +26,12 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "KW24D": {
@@ -44,16 +44,16 @@
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",

--- a/configs/mesh_thread_ATMEL.json
+++ b/configs/mesh_thread_ATMEL.json
@@ -28,7 +28,7 @@
         "K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_thread_ATMEL.json
+++ b/configs/mesh_thread_ATMEL.json
@@ -26,12 +26,12 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "KW24D": {
@@ -40,16 +40,16 @@
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",

--- a/configs/mesh_thread_MCR20A.json
+++ b/configs/mesh_thread_MCR20A.json
@@ -28,7 +28,7 @@
         "K64F": {
             "LED": "LED_RED",
             "BUTTON": "SW2",
-            "RELAY_CONTROL": "D3"
+            "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
             "LED": "LED_RED",

--- a/configs/mesh_thread_MCR20A.json
+++ b/configs/mesh_thread_MCR20A.json
@@ -26,12 +26,12 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2",
             "RELAY_CONTROL": "ARDUINO_UNO_D3"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "KW24D": {
@@ -40,16 +40,16 @@
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",

--- a/configs/mesh_wisun_S2LP.json
+++ b/configs/mesh_wisun_S2LP.json
@@ -24,16 +24,16 @@
             "target.device_has_add": ["802_15_4_PHY"]
         },
         "K64F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "K66F": {
-            "LED": "LED_RED",
+            "LED": "LED1",
             "BUTTON": "SW2"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         }
     }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -24,37 +24,37 @@
             "target.network-default-interface-type": "MESH"
         },
         "K64F": {
-            "LED": "LED_RED",
-            "BUTTON": "SW2"
+            "LED": "LED1",
+            "BUTTON": "BUTTON1"
         },
         "K66F": {
-            "LED": "LED_RED",
-            "BUTTON": "SW2"
+            "LED": "LED1",
+            "BUTTON": "BUTTON1"
         },
         "KW24D": {
             "LED": "LED1",
-            "BUTTON": "SW1"
+            "BUTTON": "BUTTON1"
         },
         "KW41Z": {
             "LED": "LED1",
-            "BUTTON": "SW3"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F401RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NUCLEO_F429ZI":  {
-            "LED": "LED_RED",
-            "BUTTON": "USER_BUTTON",
+            "LED": "LED1",
+            "BUTTON": "BUTTON1",
             "BUTTON_MODE": "PullDown"
         },
         "NUCLEO_F411RE": {
             "LED": "NC",
-            "BUTTON": "USER_BUTTON"
+            "BUTTON": "BUTTON1"
         },
         "NCS36510": {
             "LED": "LED1",
-            "BUTTON": "SW2"
+            "BUTTON": "BUTTON1"
         }
     }
 }


### PR DESCRIPTION
This PR updates this example to use the new Arduino pin names (e.g. D0 -> ARDUINO_UNO_D0).